### PR TITLE
o upstream image restored. changing redis image back to reg.c.o

### DIFF
--- a/openshift.yaml
+++ b/openshift.yaml
@@ -365,7 +365,7 @@ objects:
           run: redis
       spec:
         containers:
-        - image: redis:3.2.11
+        - image: registry.centos.org/centos/redis-32-centos7:latest
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 3


### PR DESCRIPTION
```
curl https://registry.centos.org/v2/centos/redis-32-centos7/tags/list
{"name":"centos/redis-32-centos7","tags":["ZTZlMTI2MjE0YT","latest"]}
```