### PR TITLE
trigger redeploy.. 

### DIFF
--- a/cico_build_deploy.sh
+++ b/cico_build_deploy.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 echo 'nothing to build here'
-echo 'everything is awesome'
+echo 'everything might be awesome'
 exit 0


### PR DESCRIPTION

redis service didn't seem to update as expected:
https://ci.centos.org/job/devtools-error-tracking-build-master/13/console

```
oc apply -f error-tracking-processed/error-tracking.yaml -n sentry-preview
configmap "sentry" configured
persistentvolumeclaim "redis-data" created
deploymentconfig "sentry-cron" configured
deploymentconfig "sentry-web" configured
deploymentconfig "sentry-worker" configured
service "redis" configured
service "sentry" configured
Error from server: cannot restore slice from map
```

```
svc/redis - nnn:6379
  dc/redis deploys registry.centos.org/centos/redis-32-centos7:latest 
    deployment #7 deployed 5 hours ago - 1 pod
    deployment #6 deployed 22 hours ago
    deployment #5 failed 22 hours ago: The deployment was cancelled by the user
...
  Volumes:
   redis-data:
    Type:	EmptyDir (a temporary directory that shares a pod's lifetime)
    Medium:	

Deployment #7 (latest):
	Name:		redis-7
	Created:	5 hours ago
	Status:		Complete
	Replicas:	1 current / 1 desired
	Selector:	deployment=redis-7,deploymentconfig=redis,run=redis
	Labels:		openshift.io/deployment-config.name=redis,run=redis,service=sentry
	Pods Status:	1 Running / 0 Waiting / 0 Succeeded / 0 Failed
Deployment #6:
	Created:	22 hours ago
	Status:		Complete
	Replicas:	0 current / 0 desired
Deployment #5:
	Created:	22 hours ago
	Status:		Failed
	Replicas:	0 current / 0 desired
```
